### PR TITLE
fix: handleError returns Error objects instead of strings

### DIFF
--- a/lib/mite-api.js
+++ b/lib/mite-api.js
@@ -43,47 +43,39 @@
     options = _.extend(defaults, options);
     api = {};
     handleResponse = function(err, response, body, done) {
-      var _body;
       if (err) {
         return done(err, null);
-      } else {
-        switch (response.req.method) {
-          case 'GET':
-          case 'PUT':
-          case 'DELETE':
-            if (response.statusCode === 200) {
-              _body = body;
-              try {
-                body = JSON.parse(body);
-              } catch (error) {
-                err = error;
-                body = _body;
-              }
-              err = null;
-            } else {
-              err = response.statusCode + body;
-            }
-            break;
-          case 'POST':
-            if (response.statusCode === 401) {
-              _body = body;
-              try {
-                body = JSON.parse(body);
-              } catch (error) {
-                err = error;
-                body = _body;
-              }
-              err = null;
-            } else {
-              err = body;
-            }
-            break;
-          default:
-            body = null;
-            err = 500;
-        }
-        return done(err, body);
       }
+      try {
+        body = JSON.parse(body);
+      } catch (error) {
+        err = error;
+      }
+      switch (response.req.method) {
+        case 'GET':
+        case 'PUT':
+        case 'DELETE':
+          if (response.statusCode === 200) {
+            err = null;
+          } else {
+            err = new Error(body.error || body);
+            err.response = response;
+          }
+          break;
+        case 'POST':
+          if (response.statusCode === 401) {
+            err = null;
+          } else {
+            err = new Error(body.error || body);
+            err.response = response;
+          }
+          break;
+        default:
+          body = null;
+          err = new Error(500);
+          err.response = response;
+      }
+      return done(err, body);
     };
     makeRequest = function(...args) {
       var done, ref, requestOptions;

--- a/test/test.js
+++ b/test/test.js
@@ -76,6 +76,56 @@
   });
 
   describe('API', function() {
+    describe('getAccount', function() {
+      it('when not found calls the callback with an error object', function(done) {
+        var mite = miteApi({
+          account: 'account',
+          apiKey: 'apikey',
+          applicationName: 'applicationname',
+          request: function(options, done) {
+            var response = {
+              statusCode: 400,
+              req: { method: 'POST' }
+            };
+            var body = {
+              error: 'Whoops! We couldn\'t find your account'
+            };
+            done(null, response, body);
+          }
+        });
+        return mite.getAccount(function(err, body) {
+          err.should.be.an.instanceOf(Error);
+          err.message.should.equal('Whoops! We couldn\'t find your account');
+          return done();
+        });
+      });
+    }); // getAccount
+
+    describe('deleteProject', function() {
+      it('calls done with rror when project was not found', function(done) {
+        var mite = miteApi({
+          account: 'account',
+          apiKey: 'apikey',
+          applicationName: 'applicationname',
+          request: function(options, done) {
+            var response = {
+              statusCode: 404,
+              req: { method: 'POST' }
+            };
+            var body = {
+              error: 'Der Datensatz ist nicht vorhanden'
+            };
+            done(null, response, body);
+          }
+        });
+        return mite.deleteProject(21, function(err, body) {
+          err.should.be.an.instanceOf(Error);
+          err.message.should.equal('Der Datensatz ist nicht vorhanden');
+          return done();
+        });
+      });
+    }); // deleteProject
+
     describe('Service', function() {
       var mite;
       mite = miteApi({


### PR DESCRIPTION
The errors returned by the API contain the status code and the JSON string body which makes it difficult to parse the message or the status code correctly. I’ve changed this so that the error is an instance of the Error object which contains the "error" from the response as `err.message` and the whole response in "err.response". This way libraries using the API can handle the error and also react on the response.

The following code will now show the real error message without JSON and status Code:

```javascript
api.deleteProject(1234, (err, body) {
	if (err) {
		console.error(err.message);
		process.exit(1);
	};
});
```