### PR TITLE
fix: check for 201 instead of 401 after POST for success

### DIFF
--- a/src/lib/mite-api.coffee
+++ b/src/lib/mite-api.coffee
@@ -66,7 +66,7 @@ module.exports = (options) ->
             err = response.statusCode + body
 
         when 'POST'
-          if response.statusCode == 401
+          if response.statusCode == 201
             _body = body;
 
             try


### PR DESCRIPTION
The `handleResponse` method checks for a 401 after A `POST` to identify a successful response which totally ignores the 201 which is actually sent by the mite API. 

This PR fixes this problem.