### PR TITLE
0.1.1 release

### DIFF
--- a/lib/mite-api.js
+++ b/lib/mite-api.js
@@ -45,6 +45,7 @@
         return done(err, null);
       }
       try {
+        // always try to parse body as JSON
         body = JSON.parse(body);
       } catch (error) {
         err = error;
@@ -61,7 +62,7 @@
           }
           break;
         case 'POST':
-          if (response.statusCode === 401) {
+          if (response.statusCode === 201) {
             err = null;
           } else {
             err = new Error(body.error || body);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "mite-api",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mite-api",
   "description": "Simple Node.js module to access the mite-api.",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "homepage": "https://github.com/marcel-devdude/mite-api",
   "license": "MIT",
   "author": {

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "test": "mocha",
     "tdd": "npm run test -- --watch",
     "watch": "grunt watch"
+    "preversion": "npm run -s build && npm test"
   },
   "dependencies": {
     "request": "^2.88.0"

--- a/package.json
+++ b/package.json
@@ -21,9 +21,10 @@
   },
   "scripts": {
     "update": "npm-check --update",
-    "test": "mocha",
+    "test": "npm run -s build && mocha",
     "tdd": "npm run test -- --watch",
-    "watch": "grunt watch"
+    "watch": "grunt watch",
+    "build": "grunt",
     "preversion": "npm run -s build && npm test"
   },
   "dependencies": {

--- a/src/lib/mite-api.coffee
+++ b/src/lib/mite-api.coffee
@@ -50,7 +50,7 @@ module.exports = (options) ->
     if err
       return done err, null
 
-    // always try to parse body as JSON
+    # always try to parse body as JSON
     try
       body = JSON.parse body
     catch err

--- a/src/test/test.coffee
+++ b/src/test/test.coffee
@@ -37,6 +37,54 @@ describe 'URL', ->
 
 describe 'API', ->
 
+  describe 'getAccount', ->
+    # mock failed getAccount request
+    getAccountRequestMock = (options, done) ->
+      response =
+        statusCode: 400,
+        req: { method: 'POST' }
+      body = {
+        error: 'Whoops! We couldn\'t find your account'
+      };
+      done null, response, body
+
+    mite = miteApi {
+      account: 'account',
+      apiKey: 'apikey',
+      applicationName: 'applicationname',
+      request: getAccountRequestMock
+    }
+
+    it 'when not found calls the callback with an error object', (done) ->
+      mite.getAccount (err, body) ->
+        err.should.be.an.instanceOf Error
+        err.message.should.equal 'Whoops! We couldn\'t find your account'
+        done()
+
+  describe 'deleteProject', ->
+    # momck a failed deleteProject request
+    deleteProjectRequestMock = (options, done) ->
+      response =
+        statusCode: 404,
+        req: { method: 'POST' }
+
+      body = {
+        error: 'Der Datensatz ist nicht vorhanden'
+      };
+      done null, response, body
+    mite = miteApi {
+      account: 'account',
+      apiKey: 'apikey',
+      applicationName: 'applicationname',
+      request: deleteProjectRequestMock
+    }
+
+    it 'calls done with rror when project was not found', (done) ->
+      mite.deleteProject 21, (err, body) ->
+        err.should.be.an.instanceOf Error
+        err.message.should.equal 'Der Datensatz ist nicht vorhanden'
+        done()
+
   describe 'Service', ->
     mite = miteApi { account: 'account', apiKey: 'apikey', applicationName: 'applicationname', request: requestMock }
 

--- a/test/test.js
+++ b/test/test.js
@@ -77,55 +77,65 @@
 
   describe('API', function() {
     describe('getAccount', function() {
-      it('when not found calls the callback with an error object', function(done) {
-        var mite = miteApi({
-          account: 'account',
-          apiKey: 'apikey',
-          applicationName: 'applicationname',
-          request: function(options, done) {
-            var response = {
-              statusCode: 400,
-              req: { method: 'POST' }
-            };
-            var body = {
-              error: 'Whoops! We couldn\'t find your account'
-            };
-            done(null, response, body);
+      var getAccountRequestMock, mite;
+      // mock failed getAccount request
+      getAccountRequestMock = function(options, done) {
+        var body, response;
+        response = {
+          statusCode: 400,
+          req: {
+            method: 'POST'
           }
-        });
+        };
+        body = {
+          error: 'Whoops! We couldn\'t find your account'
+        };
+        return done(null, response, body);
+      };
+      mite = miteApi({
+        account: 'account',
+        apiKey: 'apikey',
+        applicationName: 'applicationname',
+        request: getAccountRequestMock
+      });
+      return it('when not found calls the callback with an error object', function(done) {
         return mite.getAccount(function(err, body) {
           err.should.be.an.instanceOf(Error);
           err.message.should.equal('Whoops! We couldn\'t find your account');
           return done();
         });
       });
-    }); // getAccount
-
+    });
     describe('deleteProject', function() {
-      it('calls done with rror when project was not found', function(done) {
-        var mite = miteApi({
-          account: 'account',
-          apiKey: 'apikey',
-          applicationName: 'applicationname',
-          request: function(options, done) {
-            var response = {
-              statusCode: 404,
-              req: { method: 'POST' }
-            };
-            var body = {
-              error: 'Der Datensatz ist nicht vorhanden'
-            };
-            done(null, response, body);
+      var deleteProjectRequestMock, mite;
+      // momck a failed deleteProject request
+      deleteProjectRequestMock = function(options, done) {
+        var body, response;
+        response = {
+          statusCode: 404,
+          req: {
+            method: 'POST'
           }
-        });
+        };
+        body = {
+          error: 'Der Datensatz ist nicht vorhanden'
+        };
+        return done(null, response, body);
+      };
+      mite = miteApi({
+        account: 'account',
+        apiKey: 'apikey',
+        applicationName: 'applicationname',
+        request: deleteProjectRequestMock
+      });
+      return it('calls done with rror when project was not found', function(done) {
         return mite.deleteProject(21, function(err, body) {
           err.should.be.an.instanceOf(Error);
           err.message.should.equal('Der Datensatz ist nicht vorhanden');
           return done();
         });
       });
-    }); // deleteProject
-
+    });
     describe('Service', function() {
       var mite;
       mite = miteApi({


### PR DESCRIPTION
Proposing a 0.1.1 release to make it easier to refer to the latest version of this library in package.json. I’m having trouble getting my CI tests running and making sure everyone is using the right version of this package when referencing it in my project using the branch in the URL: https://github.com/Ephigenia/mite-cli/blob/develop/package.json#L72

That’s why I would suppose merging this branch and releasing a 0.1.1 version to npm.

# Changes

- adds a `preversion` script which builds the javascript files and runs the tests to make sure that always the latest javascript version of the coffeescript is released
- builds the javascript files before running the tests
- re-adds two tests for failing `getAccount` and `deleteProject` to the coffeescript files which where added to the javascript test.js file before

