### PR TITLE
Changed mite domain name to mite.de

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # mite-api
 
-Simple Node.js module to access the [mite-api](http://mite.yo.lk/en/api/).
+Simple Node.js module to access the [mite-api](http://mite.de/en/api/).
 
 ## Getting Started
 Install the module with: `npm install mite-api`
@@ -25,7 +25,7 @@ Available options are:
 
 ## API-Methods
 
-The optional `options`-object is passed as query parameters to the api-url. For example you can add properties to limit the output. See the [mite-api](http://mite.yo.lk/en/api/) for more information.
+The optional `options`-object is passed as query parameters to the api-url. For example you can add properties to limit the output. See the [mite-api](http://mite.de/en/api/) for more information.
 
 ```javascript
 var options = {
@@ -33,7 +33,7 @@ var options = {
     page: 2
 };
 
-// more complex example (http://mite.yo.lk/en/api/time-entries.html)
+// more complex example (http://mite.de/en/api/time-entries.html)
 var options = {
     customer_id: 1,
     billable: true,

--- a/lib/mite-api.js
+++ b/lib/mite-api.js
@@ -11,7 +11,7 @@ module.exports = function(options) {
     apiKey: false,
     applicationName: false,
     apiProtocol: 'https:',
-    apiUrl: 'mite.yo.lk',
+    apiUrl: 'mite.de',
     apiExtension: '.json',
     query: false,
     request: request,

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "keywords": [
     "api",
     "mite",
-    "mite.yo.lk",
+    "mite.de",
     "time-tracking",
     "timetracking"
   ],

--- a/test/mock/request.js
+++ b/test/mock/request.js
@@ -98,7 +98,7 @@ module.exports = function(options, done) {
     }
   };
   switch (url) {
-    case 'https://account.mite.yo.lk/services.json':
+    case 'https://account.mite.de/services.json':
       if (options.method === 'POST') {
         response.statusCode = 401;
         body = serviceMock;
@@ -107,15 +107,15 @@ module.exports = function(options, done) {
         body = [serviceMock];
       }
       break;
-    case 'https://account.mite.yo.lk/services/archived.json':
+    case 'https://account.mite.de/services/archived.json':
       response.statusCode = 200;
       body = [serviceMock];
       break;
-    case 'https://account.mite.yo.lk/services/1.json':
+    case 'https://account.mite.de/services/1.json':
       response.statusCode = 200;
       body = serviceMock;
       break;
-    case 'https://account.mite.yo.lk/customers.json':
+    case 'https://account.mite.de/customers.json':
       if (options.method === 'POST') {
         response.statusCode = 401;
         body = customerMock;
@@ -124,15 +124,15 @@ module.exports = function(options, done) {
         body = [customerMock];
       }
       break;
-    case 'https://account.mite.yo.lk/customers/archived.json':
+    case 'https://account.mite.de/customers/archived.json':
       response.statusCode = 200;
       body = [customerMock];
       break;
-    case 'https://account.mite.yo.lk/customers/1.json':
+    case 'https://account.mite.de/customers/1.json':
       response.statusCode = 200;
       body = customerMock;
       break;
-    case 'https://account.mite.yo.lk/projects.json':
+    case 'https://account.mite.de/projects.json':
       if (options.method === 'POST') {
         response.statusCode = 401;
         body = projectMock;
@@ -141,31 +141,31 @@ module.exports = function(options, done) {
         body = [projectMock];
       }
       break;
-    case 'https://account.mite.yo.lk/projects/archived.json':
+    case 'https://account.mite.de/projects/archived.json':
       response.statusCode = 200;
       body = [projectMock];
       break;
-    case 'https://account.mite.yo.lk/projects/1.json':
+    case 'https://account.mite.de/projects/1.json':
       response.statusCode = 200;
       body = projectMock;
       break;
-    case 'https://account.mite.yo.lk/users.json':
+    case 'https://account.mite.de/users.json':
       response.statusCode = 200;
       body = [userMock];
       break;
-    case 'https://account.mite.yo.lk/users/archived.json':
+    case 'https://account.mite.de/users/archived.json':
       response.statusCode = 200;
       body = [userMock];
       break;
-    case 'https://account.mite.yo.lk/users/1.json':
+    case 'https://account.mite.de/users/1.json':
       response.statusCode = 200;
       body = userMock;
       break;
-    case 'https://account.mite.yo.lk/daily/2013/1/1.json':
+    case 'https://account.mite.de/daily/2013/1/1.json':
       response.statusCode = 200;
       body = [entryMock];
       break;
-    case 'https://account.mite.yo.lk/time_entries.json':
+    case 'https://account.mite.de/time_entries.json':
       if (options.method === 'POST') {
         response.statusCode = 401;
         body = entryMock;
@@ -174,15 +174,15 @@ module.exports = function(options, done) {
         body = [entryMock];
       }
       break;
-    case 'https://account.mite.yo.lk/time_entries/1.json':
+    case 'https://account.mite.de/time_entries/1.json':
       response.statusCode = 200;
       body = entryMock;
       break;
-    case 'https://account.mite.yo.lk/myself.json':
+    case 'https://account.mite.de/myself.json':
       response.statusCode = 200;
       body = userMock;
       break;
-    case 'https://account.mite.yo.lk/account.json':
+    case 'https://account.mite.de/account.json':
       response.statusCode = 200;
       body = accountMock;
       break;

--- a/test/test.js
+++ b/test/test.js
@@ -34,7 +34,7 @@ describe('URL', function() {
       apiKey: 'apikey',
       applicationName: 'applicationname'
     });
-    return mite.getUrl('services').should.equal('https://account.mite.yo.lk/services.json');
+    return mite.getUrl('services').should.equal('https://account.mite.de/services.json');
   });
   it('should be a valid API-URL with an api_key query-parameter', function() {
     var mite;
@@ -44,7 +44,7 @@ describe('URL', function() {
       applicationName: 'applicationname',
       query: true
     });
-    return mite.getUrl('services').should.equal('https://account.mite.yo.lk/services.json?api_key=apikey');
+    return mite.getUrl('services').should.equal('https://account.mite.de/services.json?api_key=apikey');
   });
   it('should be a valid API-URL with a filter query-parameter', function() {
     var mite;
@@ -56,7 +56,7 @@ describe('URL', function() {
     return mite.getUrl('services', {
       limit: 50,
       page: 2
-    }).should.equal('https://account.mite.yo.lk/services.json?limit=50&page=2');
+    }).should.equal('https://account.mite.de/services.json?limit=50&page=2');
   });
   return it('should be a valid API-URL with placeholders', function() {
     var mite;
@@ -69,7 +69,7 @@ describe('URL', function() {
       year: 2013,
       month: 1,
       day: 1
-    }).should.equal('https://account.mite.yo.lk/daily/2013/1/1.json');
+    }).should.equal('https://account.mite.de/daily/2013/1/1.json');
   });
 });
 


### PR DESCRIPTION
I changed the used api domain to the current {accountName}.mite.de. This is just for future-proofing: the legacy schema will continue to work for the foreseeable future.

Background: https://mite.de/en/blog/2023/02/14/upcoming-move-to-mite-de/
